### PR TITLE
Add anyhow error handling and remove remaining unwraps

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +453,7 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 name = "twisterl-rs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "dyn-clone",
  "nalgebra",
  "petgraph",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,6 +15,7 @@ rand = "0.8.4"
 rayon = "1.1.0"
 petgraph = "0.6.5"
 dyn-clone = "1.0.19"
+anyhow = "1.0.98"
 
 [profile.release]
 opt-level = 3

--- a/rust/src/collector/az.rs
+++ b/rust/src/collector/az.rs
@@ -12,10 +12,11 @@ that they have been altered from the originals.
 */
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
+use anyhow::Result;
 
 use crate::rl::env::Env;
 use crate::nn::policy::{Policy, sample};
-use crate::collector::collector::{CollectedData, Collector};
+use crate::collector::collector::{CollectedData, Collector, merge};
 use crate::rl::search::predict_probs_mcts;
 
 #[derive(Clone)]
@@ -107,32 +108,32 @@ impl AZCollector {
 }
 
 impl Collector for AZCollector {
-    fn collect(&self, env: &Box<dyn Env>, policy: &Policy) -> CollectedData {
+    fn collect(&self, env: &Box<dyn Env>, policy: &Policy) -> Result<CollectedData> {
         if self.num_cores == 1 {
-            merge(
+            Ok(merge(
                 (0..self.num_episodes).into_iter()  
                     .map(|_| self.single_collect(env, policy)) 
                     .collect()
-            )
+            )?)
         } else {
-            let pool: rayon::ThreadPool = ThreadPoolBuilder::new().num_threads(self.num_cores).build().unwrap();
+            let pool: rayon::ThreadPool = ThreadPoolBuilder::new().num_threads(self.num_cores).build()?;
             // Use the thread pool to run the generation in parallel
-            merge(pool.install(|| {
+            Ok(merge(pool.install(|| {
                 (0..self.num_episodes).into_par_iter()  // Create a parallel iterator over the range 0..num_episodes
                     .map(|_| self.single_collect(env, policy)) 
                     .collect()
-            }))
+            }))?)
         }
     }
 }
 
 /// Merge many episodes into one
-fn merge(mut chunks: Vec<CollectedData>) -> CollectedData {
-    let mut merged = chunks
-        .pop()
-        .expect("AZCollector::collect: no episodes to merge");
+fn merge(
+    mut chunks: Vec<CollectedData>,
+) -> Result<CollectedData> {
+    let mut merged = chunks.pop().ok_or(anyhow!("Something went wrong. No data in collected data chunks to merge. "))?;
     for chunk in chunks {
         merged.merge(&chunk);
     }
-    merged
+    Ok(merged)
 }

--- a/rust/src/collector/az.rs
+++ b/rust/src/collector/az.rs
@@ -127,13 +127,3 @@ impl Collector for AZCollector {
     }
 }
 
-/// Merge many episodes into one
-fn merge(
-    mut chunks: Vec<CollectedData>,
-) -> Result<CollectedData> {
-    let mut merged = chunks.pop().ok_or(anyhow!("Something went wrong. No data in collected data chunks to merge. "))?;
-    for chunk in chunks {
-        merged.merge(&chunk);
-    }
-    Ok(merged)
-}

--- a/rust/src/collector/collector.rs
+++ b/rust/src/collector/collector.rs
@@ -12,6 +12,8 @@ that they have been altered from the originals.
 */
 
 use std::collections::HashMap;
+use anyhow::{anyhow, Result};
+
 use crate::nn::policy::Policy;
 use crate::rl::env::Env;
 
@@ -30,6 +32,15 @@ pub struct CollectedData {
     pub actions: Vec<usize>,
     /// Additional data (e.g., GAE advantages, returns)
     pub additional_data: HashMap<String, Vec<f32>>,
+}
+
+/// Merge many episodes into one
+pub fn merge(mut chunks: Vec<CollectedData>) -> Result<CollectedData> {
+    let mut merged = chunks.pop().ok_or(anyhow!("Something went wrong. No data in collected data chunks to merge. "))?;
+    for chunk in chunks {
+        merged.merge(&chunk);
+    }
+    Ok(merged)
 }
 
 impl CollectedData {
@@ -73,7 +84,7 @@ impl CollectedData {
 }
 
 /// A generic trait for collecting data.
-pub trait Collector: Send + Sync{
+pub trait Collector: Send + Sync {
     /// Runs the collection process and returns accumulated data.
-    fn collect(&self, env: &Box<dyn Env>, policy: &Policy) -> CollectedData;
+    fn collect(&self, env: &Box<dyn Env>, policy: &Policy) -> Result<CollectedData>;
 }

--- a/rust/src/python_interface/collector.rs
+++ b/rust/src/python_interface/collector.rs
@@ -1,4 +1,16 @@
-// Now create a Python-facing proxy struct using PyO3
+// -*- coding: utf-8 -*-
+/* 
+(C) Copyright 2025 IBM. All Rights Reserved.
+
+This code is licensed under the Apache License, Version 2.0. You may
+obtain a copy of this license in the LICENSE.txt file in the root directory
+of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+Any modifications or derivative works of this code must retain this
+copyright notice, and modified files need to carry a notice indicating
+that they have been altered from the originals.
+*/
+
 use pyo3::prelude::*;
 use std::collections::HashMap;
 

--- a/rust/src/python_interface/collector.rs
+++ b/rust/src/python_interface/collector.rs
@@ -7,7 +7,7 @@ use crate::collector::ppo::PPOCollector;
 use crate::collector::az::AZCollector;
 use crate::python_interface::policy::PyPolicy;
 use crate::python_interface::env::PyBaseEnv;
-
+use crate::python_interface::error_mapping::MyError;
 
 #[pyclass(name="CollectedData")]
 pub struct PyCollectedData {
@@ -117,9 +117,9 @@ pub struct PyBaseCollector {
 #[pymethods]
 impl PyBaseCollector {
     // Collects Data
-    fn collect(&self, env: PyRef<PyBaseEnv>, policy: &PyPolicy) -> PyCollectedData{
-        let collected_data = self.collector.collect(&env.env, &*policy.policy);
-        PyCollectedData { inner: collected_data }
+    fn collect(&self, env: PyRef<PyBaseEnv>, policy: &PyPolicy) -> PyResult<PyCollectedData>{
+        let collected_data = self.collector.collect(&env.env, &*policy.policy).map_err(MyError::from)?;
+        Ok(PyCollectedData { inner: collected_data })
     }
 }
 

--- a/rust/src/python_interface/env.rs
+++ b/rust/src/python_interface/env.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use crate::rl::env::Env;
 use crate::envs::puzzle::Puzzle;
 use crate::python_interface::policy::PyPolicy;
+use crate::python_interface::error_mapping::MyError;
 use crate::rl::solve::solve;
 use crate::rl::evaluate::evaluate;
 
@@ -140,6 +141,6 @@ pub fn evaluate_py(py_env: PyRef<PyBaseEnv>,
     seed: usize,          // unused for now
     C: f32,
     max_expand_depth: usize,
-    num_cores: usize) -> (f32, f32) {
-    evaluate(&py_env.env, &*policy.policy, num_episodes, deterministic, num_searches, num_mcts_searches, seed, C, max_expand_depth, num_cores)
+    num_cores: usize) -> PyResult<(f32, f32)> {
+    Ok(evaluate(&py_env.env, &*policy.policy, num_episodes, deterministic, num_searches, num_mcts_searches, seed, C, max_expand_depth, num_cores).map_err(MyError::from)?)
 }

--- a/rust/src/python_interface/env.rs
+++ b/rust/src/python_interface/env.rs
@@ -1,3 +1,16 @@
+// -*- coding: utf-8 -*-
+/* 
+(C) Copyright 2025 IBM. All Rights Reserved.
+
+This code is licensed under the Apache License, Version 2.0. You may
+obtain a copy of this license in the LICENSE.txt file in the root directory
+of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+Any modifications or derivative works of this code must retain this
+copyright notice, and modified files need to carry a notice indicating
+that they have been altered from the originals.
+*/
+
 use pyo3::prelude::*;
 use crate::rl::env::Env;
 use crate::envs::puzzle::Puzzle;

--- a/rust/src/python_interface/error_mapping.rs
+++ b/rust/src/python_interface/error_mapping.rs
@@ -1,18 +1,31 @@
+// -*- coding: utf-8 -*-
+/* 
+(C) Copyright 2025 IBM. All Rights Reserved.
+
+This code is licensed under the Apache License, Version 2.0. You may
+obtain a copy of this license in the LICENSE.txt file in the root directory
+of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+
+Any modifications or derivative works of this code must retain this
+copyright notice, and modified files need to carry a notice indicating
+that they have been altered from the originals.
+*/
+
 use pyo3::prelude::*;
 use pyo3::exceptions::PyRuntimeError;
 use anyhow::Error as AnyhowError;
 
-// 1. Definimos un struct local que envuelva a anyhow::Error
+// Code to map Rust errors to Python exceptions
+// Wrapper for anyhow::Error
 pub struct MyError(AnyhowError);
 
-// 2. Implementamos `From<anyhow::Error> for MyError` para facilitar el wrapping
+// `From<anyhow::Error> for MyError` for wrapping
 impl From<AnyhowError> for MyError {
     fn from(err: AnyhowError) -> MyError {
         MyError(err)
     }
 }
 
-// 3. Ahora podemos implementar `From<MyError> for PyErr` en nuestro crate
 impl From<MyError> for PyErr {
     fn from(err: MyError) -> PyErr {
         PyRuntimeError::new_err(err.0.to_string())

--- a/rust/src/python_interface/error_mapping.rs
+++ b/rust/src/python_interface/error_mapping.rs
@@ -1,0 +1,20 @@
+use pyo3::prelude::*;
+use pyo3::exceptions::PyRuntimeError;
+use anyhow::Error as AnyhowError;
+
+// 1. Definimos un struct local que envuelva a anyhow::Error
+pub struct MyError(AnyhowError);
+
+// 2. Implementamos `From<anyhow::Error> for MyError` para facilitar el wrapping
+impl From<AnyhowError> for MyError {
+    fn from(err: AnyhowError) -> MyError {
+        MyError(err)
+    }
+}
+
+// 3. Ahora podemos implementar `From<MyError> for PyErr` en nuestro crate
+impl From<MyError> for PyErr {
+    fn from(err: MyError) -> PyErr {
+        PyRuntimeError::new_err(err.0.to_string())
+    }
+}

--- a/rust/src/python_interface/mod.rs
+++ b/rust/src/python_interface/mod.rs
@@ -13,6 +13,7 @@ that they have been altered from the originals.
 
 pub mod collector;
 pub mod env;
+pub mod error_mapping;
 pub mod layers;
 pub mod modules;
 pub mod policy;

--- a/rust/src/rl/evaluate.rs
+++ b/rust/src/rl/evaluate.rs
@@ -13,6 +13,7 @@ that they have been altered from the originals.
 
 use rayon::prelude::*;
 use rayon::ThreadPoolBuilder;
+use anyhow::Result;
 
 use crate::rl::env::Env;
 use crate::nn::policy::Policy;
@@ -29,7 +30,7 @@ pub fn evaluate(
     C: f32,
     max_expand_depth: usize,
     num_cores: usize,
-) -> (f32, f32) {
+) -> Result<(f32, f32)> {
     let mut env = env.clone();
     if num_cores <= 1 {
         let mut successes = 0.0;
@@ -48,7 +49,7 @@ pub fn evaluate(
             successes += success;
             rewards  += reward;
         }
-        (successes/(num_episodes as f32), rewards/(num_episodes as f32))
+        Ok((successes/(num_episodes as f32), rewards/(num_episodes as f32)))
     } else {
         // Parallel evaluation via Rayon
         let pool = ThreadPoolBuilder::new()
@@ -83,6 +84,6 @@ pub fn evaluate(
                 )
         });
 
-        (successes / (num_episodes as f32), total_vals / (num_episodes as f32))
+        Ok((successes / (num_episodes as f32), total_vals / (num_episodes as f32)))
     }
 }

--- a/rust/src/rl/search.rs
+++ b/rust/src/rl/search.rs
@@ -16,7 +16,6 @@ use crate::rl::env::Env;
 
 use crate::rl::tree::Tree;
 use crate::nn::policy::{sample, Policy};
-use dyn_clone::clone_box;
 
 pub struct MCTSNode {
     pub state: Box<dyn Env>,

--- a/rust/src/rl/search.rs
+++ b/rust/src/rl/search.rs
@@ -16,6 +16,7 @@ use crate::rl::env::Env;
 
 use crate::rl::tree::Tree;
 use crate::nn::policy::{sample, Policy};
+use dyn_clone::clone_box;
 
 pub struct MCTSNode {
     pub state: Box<dyn Env>,


### PR DESCRIPTION
Fixes #9 

Remove unwraps  by using anyhow error handling library and wrap python return type in proper errors.